### PR TITLE
feat: 任意の内部パネル（非輻射ノード）を追加可能にする

### DIFF
--- a/src/spacecraft_thermal_multi_node_analysis/multi_node_analysis.py
+++ b/src/spacecraft_thermal_multi_node_analysis/multi_node_analysis.py
@@ -145,6 +145,10 @@ def run_earth_orbit_analysis(
     for component in config.components.values():
         node.add_component(component)
 
+    # 内部パネルの追加（任意）
+    for internal_panel in config.internal_panels.values():
+        node.add_internal_panel(internal_panel)
+
     # コンダクタンス行列の設定
     node.set_conductance_matrix(config.conductance_matrix, config.enable_conductance)
 
@@ -213,6 +217,10 @@ def run_earth_orbit_analysis(
     for component_name in node.components.keys():
         temperatures[component_name] = [node.get_component_temperature(component_name)]
 
+    # 内部パネルの温度も記録
+    for panel_name in node.internal_panels.keys():
+        temperatures[panel_name] = [node.get_internal_panel_temperature(panel_name)]
+
     # 時間積分
     for t_idx, t in enumerate(times):
         if t_idx == 0:
@@ -242,6 +250,11 @@ def run_earth_orbit_analysis(
         for component_name in node.components.keys():
             temperatures[component_name].append(
                 node.get_component_temperature(component_name),
+            )
+        # 内部パネルの温度も記録
+        for panel_name in node.internal_panels.keys():
+            temperatures[panel_name].append(
+                node.get_internal_panel_temperature(panel_name),
             )
 
     return times.tolist(), temperatures, node.heat_input_records, list(in_eclipse_ts)
@@ -286,6 +299,10 @@ def run_deep_space_analysis(
     # コンポーネントの追加
     for component in config.components.values():
         node.add_component(component)
+
+    # 内部パネルの追加（任意）
+    for internal_panel in config.internal_panels.values():
+        node.add_internal_panel(internal_panel)
 
     # コンダクタンス行列の設定
     node.set_conductance_matrix(config.conductance_matrix, config.enable_conductance)

--- a/src/spacecraft_thermal_multi_node_analysis/utils/config_loader.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/config_loader.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import yaml
 
-from .dataclasses import ComponentProperties, MaterialProperties, SurfaceMaterial
+from .dataclasses import ComponentProperties, InternalPanel, MaterialProperties, SurfaceMaterial
 
 if TYPE_CHECKING:
     from .satellite_config import PanelOpticalConfig, PanelStructuralConfig
@@ -134,3 +134,60 @@ def load_component_properties(settings_dir: str) -> dict[str, ComponentPropertie
         )
 
     return component_properties
+
+
+def load_internal_panels(
+    settings_dir: str,
+    material_properties: dict[str, MaterialProperties],
+) -> dict[str, InternalPanel]:
+    """内部パネル(外部輻射を持たない内部ノード)を読み込む（任意・ファイルが無ければ空）。
+
+    settings_dir/internal_panels.yaml の例:
+        internal_panels:
+          OPTICS:
+            name: "Optics Panel (SiC)"
+            material: "SiC"        # material_properties.yaml の材料名
+            area: 0.09             # [m^2]
+            thickness: 10.0        # [mm]
+            internal_heat: 2.0     # [W]（任意）
+            conductances:          # [W/K] 各構体パネルへの伝導結合
+              PX: 0.25
+              PZ: 0.30
+    質量は material+寸法、または mass[kg]+specific_heat[J/kg/K] で定義可。
+    """
+    file_path = os.path.join(settings_dir, "internal_panels.yaml")
+    if not os.path.exists(file_path):
+        return {}
+
+    with open(file_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    internal_panels: dict[str, InternalPanel] = {}
+    for key, props in (data.get("internal_panels") or {}).items():
+        # 熱容量の決定: material+寸法 を優先、無ければ mass+specific_heat
+        if "material" in props:
+            mat_name = props["material"]
+            if mat_name not in material_properties:
+                raise ValueError(f"内部パネル {key} の材料 {mat_name} が material_properties に定義されていません")
+            mat = material_properties[mat_name]
+            volume = float(props["area"]) * (float(props["thickness"]) * 1e-3)  # area[m^2] x thickness[mm->m]
+            heat_capacity = mat.density * volume * mat.specific_heat
+        elif "mass" in props and "specific_heat" in props:
+            heat_capacity = float(props["mass"]) * float(props["specific_heat"])
+        else:
+            raise ValueError(
+                f"内部パネル {key} は material+area+thickness か mass+specific_heat のいずれかで熱容量を定義してください",
+            )
+
+        conductances = {str(p): float(g) for p, g in (props.get("conductances") or {}).items()}
+        if not conductances:
+            raise ValueError(f"内部パネル {key} には conductances（構体パネルへの伝導結合）が必要です")
+
+        internal_panels[key] = InternalPanel(
+            name=props.get("name", key),
+            heat_capacity_J_K=heat_capacity,
+            conductances=conductances,
+            internal_heat=float(props.get("internal_heat", 0.0)),
+        )
+
+    return internal_panels

--- a/src/spacecraft_thermal_multi_node_analysis/utils/dataclasses.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/dataclasses.py
@@ -65,3 +65,22 @@ class ComponentProperties:
     def heat_capacity(self) -> float:
         """熱容量 [J/K]を計算"""
         return self.mass * self.specific_heat
+
+
+@dataclass
+class InternalPanel:
+    """内部パネル（外部輻射を持たない内部ノード）。
+
+    任意個数を追加でき、複数の構体パネル(6面)へ熱コンダクタンスで結合される。
+    熱容量は material+寸法、または mass+specific_heat から定義（loaderで算出）。
+    外部輻射(太陽/アルベド/地球赤外)および面間輻射(view factor)は持たず、伝導のみで結合する。
+    """
+
+    name: str  # 表示名（CSV列名にもなる）
+    heat_capacity_J_K: float  # 熱容量 [J/K]
+    conductances: dict[str, float]  # {構体パネル名: 熱コンダクタンス [W/K]}
+    internal_heat: float = 0.0  # 自前発熱 [W]（任意）
+
+    @property
+    def heat_capacity(self) -> float:
+        return self.heat_capacity_J_K

--- a/src/spacecraft_thermal_multi_node_analysis/utils/satellite_config.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/satellite_config.py
@@ -8,11 +8,12 @@ from .config_loader import (
     load_component_properties,
     load_conductance_matrix,
     load_constants,
+    load_internal_panels,
     load_material_properties,
     load_panel_material_assignments,
     load_surface_properties,
 )
-from .dataclasses import ComponentProperties, MaterialProperties, SurfaceMaterial
+from .dataclasses import ComponentProperties, InternalPanel, MaterialProperties, SurfaceMaterial
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class SatelliteConfiguration:
     conductance_matrix: pd.DataFrame | None  # パネル間の熱伝導率 [W/K]（Noneの場合は無効）
     enable_conductance: bool  # パネル間の熱伝導（Cij）を有効にするかどうか
     components: dict[str, ComponentProperties]  # コンポーネントの熱物性値
+    internal_panels: dict[str, InternalPanel]  # 内部パネル（任意・外部輻射なし・複数面へ伝導結合）
 
     @classmethod
     def from_config_files(cls, settings_dir: str) -> "SatelliteConfiguration":
@@ -58,6 +60,7 @@ class SatelliteConfiguration:
         material_properties = load_material_properties(settings_dir)
         panel_material_assignments = load_panel_material_assignments(settings_dir)
         components = load_component_properties(settings_dir)
+        internal_panels = load_internal_panels(settings_dir, material_properties)
 
         # コンダクタンス行列の有効/無効を取得
         enable_conductance = constants["analysis_parameters"].get(
@@ -119,6 +122,14 @@ class SatelliteConfiguration:
                     f"コンポーネント {name} の取り付けパネル {component.mounting_panel} が存在しません",
                 )
 
+        # 内部パネルの設定を検証（結合先パネルが存在するか）
+        for name, ipanel in internal_panels.items():
+            for panel_name in ipanel.conductances:
+                if panel_name not in panel_material_assignments:
+                    raise ValueError(
+                        f"内部パネル {name} の結合先パネル {panel_name} が存在しません",
+                    )
+
         return cls(
             dimensions=constants["satellite_dimensions"],
             internal_heat=constants["internal_heat"],  # 面ごとの内部発熱をそのまま使用
@@ -129,4 +140,5 @@ class SatelliteConfiguration:
             conductance_matrix=conductance_matrix,
             enable_conductance=enable_conductance,
             components=components,
+            internal_panels=internal_panels,
         )

--- a/src/spacecraft_thermal_multi_node_analysis/utils/thermal_utils.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/thermal_utils.py
@@ -11,6 +11,7 @@ from .config_loader import (
 from .dataclasses import (
     ComponentProperties,
     HeatInputRecord,
+    InternalPanel,
     MaterialProperties,
     MLINode,
     SurfaceMaterial,
@@ -386,6 +387,9 @@ class ThermalNode:
         # コンポーネント関連の属性を追加
         self.components: dict[str, ComponentProperties] = {}
         self.component_temperatures: dict[str, float] = {}
+        # 内部パネル（外部輻射なし・複数面へ伝導結合）
+        self.internal_panels: dict[str, InternalPanel] = {}
+        self.internal_panel_temperatures: dict[str, float] = {}
 
     def add_surface(self, surface: Surface):
         """面を追加し、初期温度を設定"""
@@ -643,6 +647,18 @@ class ThermalNode:
         # コンポーネントの熱収支を追加
         heat_balances.update(component_heat_balances)
 
+        # 内部パネルの熱収支を計算（外部輻射なし、複数構体パネルへの伝導 + 自前発熱）
+        for panel in self.internal_panels.values():
+            panel_node_temp = self.internal_panel_temperatures[panel.name]
+            node_heat = panel.internal_heat
+            for surface_name, conductance in panel.conductances.items():
+                surface_temp = self.temperatures[surface_name]
+                q = conductance * (surface_temp - panel_node_temp)  # 構体→内部パネル
+                node_heat += q
+                # 反作用: 構体パネル側は同量を失う（エネルギー保存）
+                heat_balances[surface_name] = heat_balances.get(surface_name, 0.0) - q
+            heat_balances[panel.name] = node_heat
+
         return heat_balances
 
     def update_temperature(
@@ -692,6 +708,16 @@ class ThermalNode:
                 self.component_temperatures[component_name] += temp_change
                 temperature_changes[component_name] = temp_change
 
+        # 内部パネルの温度更新
+        for panel_name, heat_balance in heat_balances.items():
+            if panel_name in self.internal_panels:
+                heat_capacity = self.internal_panels[panel_name].heat_capacity
+                temp_change = heat_balance * time_step / heat_capacity
+                max_temp_change = 100.0  # 最大温度変化 [K/step]
+                temp_change = np.clip(temp_change, -max_temp_change, max_temp_change)
+                self.internal_panel_temperatures[panel_name] += temp_change
+                temperature_changes[panel_name] = temp_change
+
         return temperature_changes
 
     def get_temperature(self, surface_name: str) -> float:
@@ -708,6 +734,8 @@ class ThermalNode:
             if surface.has_mli:
                 assert surface.mli_node is not None, "surface.mli_node should not be none if surface.has_mli is True."
                 temps[f"{surface_name}_MLI"] = surface.mli_node.temperature
+        # 内部パネルの温度も追加
+        temps.update(self.internal_panel_temperatures)
         return temps
 
     def get_mli_temperature(self, surface_name: str) -> float | None:
@@ -752,6 +780,31 @@ class ThermalNode:
         if component_name not in self.component_temperatures:
             raise ValueError(f"コンポーネント {component_name} は存在しません")
         return self.component_temperatures[component_name]
+
+    def add_internal_panel(self, panel: InternalPanel):
+        """内部パネルを追加し、初期温度を設定。
+
+        結合先の構体パネルが存在することを確認し、初期温度は結合先パネル温度の平均にする。
+        """
+        for surface_name in panel.conductances:
+            if surface_name not in self.surfaces:
+                raise ValueError(
+                    f"内部パネル {panel.name} の結合先パネル {surface_name} が存在しません",
+                )
+        self.internal_panels[panel.name] = panel
+        # 初期温度は結合先パネル温度の平均（無ければ initial_temp）
+        if panel.conductances:
+            self.internal_panel_temperatures[panel.name] = float(
+                np.mean([self.temperatures[s] for s in panel.conductances]),
+            )
+        else:
+            self.internal_panel_temperatures[panel.name] = self.initial_temp
+
+    def get_internal_panel_temperature(self, panel_name: str) -> float:
+        """特定の内部パネルの温度を取得"""
+        if panel_name not in self.internal_panel_temperatures:
+            raise ValueError(f"内部パネル {panel_name} は存在しません")
+        return self.internal_panel_temperatures[panel_name]
 
 
 def calculate_radiative_conductance_matrix(


### PR DESCRIPTION
 ## 概要
  外部輻射を持たない**内部パネル（内部ノード）**を任意個数定義できるようにします。
  光学ベンチ／光学パネルのような「筐体内部に支持され、宇宙空間へ直接放熱せず、複数の構体パネルへ熱伝導で結合する」要素を、第一級のノードとして熱モデルに追加できます。

  従来この種の要素は単一パネルへ伝導する `component` でしか表現できず、
  - 1枚のパネルにしか結合できない
  - 「パネル」概念として扱えない
  という制約がありました。本PRはこれを解消します。

  ## 追加機能
  新しい任意設定ファイル `settings_dir/internal_panels.yaml`（無ければ従来どおり無効）で、内部パネルを定義できます。各内部パネルは:

  - **外部輻射を持たない**（太陽／アルベド／地球赤外、および面間view factor輻射なし）
  - **複数の構体パネルへ熱コンダクタンス[W/K]で結合**できる
  - 熱容量を **material + 面積×厚み**、または **mass + specific_heat** で定義できる
  - 任意の `internal_heat [W]` を持てる
  - 出力CSVに**温度列として追加**される

  エネルギーは保存されます（各構体パネルは内部ノードが伝導で得た分だけ失う）。

  ### 設定例
  ```yaml
  internal_panels:
    OPTICS:
      name: "Optics Panel (SiC)"
      material: "SiC"        # material_properties.yaml の材料名
      area: 0.09             # [m^2]
      thickness: 10.0        # [mm]
      internal_heat: 2.0     # [W]（任意）
      conductances:          # [W/K] 複数パネルへ結合可
        PX: 0.25
        PZ: 0.30
```

  ## 変更ファイル

  - utils/dataclasses.py: InternalPanel を追加
  - utils/config_loader.py: load_internal_panels() を追加
  - utils/satellite_config.py: 読み込み・検証（結合先パネルの存在チェック）・フィールド追加
  - utils/thermal_utils.py: add_internal_panel()、熱収支への寄与と温度積分
  - multi_node_analysis.py: 内部パネルの登録と温度記録

## 後方互換性

  internal_panels.yaml が存在しなければ内部パネルは0個で、挙動は従来と完全一致します。
  既存の回帰テスト（既定設定での温度履歴比較）はPASSします。

## テスト

  - 既存 pytest 2件 PASS（後方互換を確認）
  - スモークテスト: SiC内部パネル(PX/PZへ伝導結合)を追加し、出力CSVに温度列が追加され、
  接続パネル温度の間に物理的に妥当に整定することを確認

<img width="1000" height="600" alt="temperature_all" src="https://github.com/user-attachments/assets/a015352d-1fa5-4213-b38b-9f42a06ba2d4" />

