### PR TITLE
feat: thermostatic heater & internal heat for components and internal panels

### DIFF
--- a/src/spacecraft_thermal_multi_node_analysis/utils/config_loader.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/config_loader.py
@@ -190,11 +190,16 @@ def load_internal_panels(
         if not conductances:
             raise ValueError(f"内部パネル {key} には conductances（構体パネルへの伝導結合）が必要です")
 
+        # オプション: サーモスタット式ヒータ heater: {setpoint_K, power_W}
+        heater = props.get("heater", {}) or {}
+
         internal_panels[key] = InternalPanel(
             name=props.get("name", key),
             heat_capacity_J_K=heat_capacity,
             conductances=conductances,
             internal_heat=float(props.get("internal_heat", 0.0)),
+            heater_setpoint_K=heater.get("setpoint_K"),
+            heater_power_W=float(heater.get("power_W", 0.0)),
         )
 
     return internal_panels

--- a/src/spacecraft_thermal_multi_node_analysis/utils/config_loader.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/config_loader.py
@@ -125,12 +125,19 @@ def load_component_properties(settings_dir: str) -> dict[str, ComponentPropertie
     # コンポーネントの定義を読み込み
     component_properties = {}
     for name, props in data["component_properties"].items():
+        # オプション: コンポーネント自身の発熱 / サーモスタット式ヒータ
+        #   internal_heat: 定常発熱 [W]
+        #   heater: {setpoint_K: 設定温度[K], power_W: 最大投入電力[W]}
+        heater = props.get("heater", {}) or {}
         component_properties[name] = ComponentProperties(
             name=props["name"],
             mass=props["mass"],
             specific_heat=props["specific_heat"],
             mounting_panel=props["mounting"]["panel"],
             thermal_conductance=props["mounting"]["thermal_conductance"],
+            internal_heat=props.get("internal_heat", 0.0),
+            heater_setpoint_K=heater.get("setpoint_K"),
+            heater_power_W=heater.get("power_W", 0.0),
         )
 
     return component_properties

--- a/src/spacecraft_thermal_multi_node_analysis/utils/dataclasses.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/dataclasses.py
@@ -92,7 +92,19 @@ class InternalPanel:
     heat_capacity_J_K: float  # 熱容量 [J/K]
     conductances: dict[str, float]  # {構体パネル名: 熱コンダクタンス [W/K]}
     internal_heat: float = 0.0  # 自前発熱 [W]（任意）
+    heater_setpoint_K: float | None = None  # サーモスタット式ヒータの設定温度 [K]（Noneでヒータ無効）
+    heater_power_W: float = 0.0  # ヒータの最大投入電力 [W]（panel_temp < setpoint のとき投入）
 
     @property
     def heat_capacity(self) -> float:
         return self.heat_capacity_J_K
+
+    def heater_heat(self, panel_temp_K: float) -> float:
+        """サーモスタット式ヒータの投入熱 [W] を返す（ON/OFF制御）。
+
+        設定温度未満なら heater_power_W を投入、それ以上なら0。
+        光学パネルの温度を設定温度で一定に保つために使用する。
+        """
+        if self.heater_setpoint_K is None:
+            return 0.0
+        return self.heater_power_W if panel_temp_K < self.heater_setpoint_K else 0.0

--- a/src/spacecraft_thermal_multi_node_analysis/utils/dataclasses.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/dataclasses.py
@@ -60,11 +60,23 @@ class ComponentProperties:
     specific_heat: float  # 比熱 [J/kg/K]
     mounting_panel: str  # 取り付けパネル名
     thermal_conductance: float  # 締結部の熱コンダクタンス [W/K]
+    internal_heat: float = 0.0  # コンポーネント自身の定常発熱 [W]（電子機器の消費電力等）
+    heater_setpoint_K: float | None = None  # サーモスタット式ヒータの設定温度 [K]（Noneでヒータ無効）
+    heater_power_W: float = 0.0  # ヒータの最大投入電力 [W]（component_temp < setpoint のとき投入）
 
     @property
     def heat_capacity(self) -> float:
         """熱容量 [J/K]を計算"""
         return self.mass * self.specific_heat
+
+    def heater_heat(self, component_temp_K: float) -> float:
+        """サーモスタット式ヒータの投入熱 [W] を返す（ON/OFF制御）。
+
+        設定温度未満なら heater_power_W を投入、それ以上なら0。
+        """
+        if self.heater_setpoint_K is None:
+            return 0.0
+        return self.heater_power_W if component_temp_K < self.heater_setpoint_K else 0.0
 
 
 @dataclass

--- a/src/spacecraft_thermal_multi_node_analysis/utils/thermal_utils.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/thermal_utils.py
@@ -642,6 +642,10 @@ class ThermalNode:
             component_temp = self.component_temperatures[component.name]
             temp_diff = panel_temp - component_temp
             heat = component.thermal_conductance * temp_diff
+            # コンポーネント自身の発熱（電子機器の消費電力等）を加算
+            heat += component.internal_heat
+            # サーモスタット式ヒータ（設定温度未満なら投入）を加算
+            heat += component.heater_heat(component_temp)
             component_heat_balances[component.name] = heat
 
         # コンポーネントの熱収支を追加

--- a/src/spacecraft_thermal_multi_node_analysis/utils/thermal_utils.py
+++ b/src/spacecraft_thermal_multi_node_analysis/utils/thermal_utils.py
@@ -651,10 +651,12 @@ class ThermalNode:
         # コンポーネントの熱収支を追加
         heat_balances.update(component_heat_balances)
 
-        # 内部パネルの熱収支を計算（外部輻射なし、複数構体パネルへの伝導 + 自前発熱）
+        # 内部パネルの熱収支を計算（外部輻射なし、複数構体パネルへの伝導 + 自前発熱 + ヒータ）
         for panel in self.internal_panels.values():
             panel_node_temp = self.internal_panel_temperatures[panel.name]
             node_heat = panel.internal_heat
+            # サーモスタット式ヒータ（設定温度未満なら投入）→ 光学パネルを設定温度で温調
+            node_heat += panel.heater_heat(panel_node_temp)
             for surface_name, conductance in panel.conductances.items():
                 surface_temp = self.temperatures[surface_name]
                 q = conductance * (surface_temp - panel_node_temp)  # 構体→内部パネル


### PR DESCRIPTION
## 概要
  熱ノード（コンポーネントおよび内部パネル）に、
  - **自己発熱 `internal_heat` [W]**（電子機器の消費電力）
  - **サーモスタット式（ON/OFF）ヒータ**（設定温度で温調）

  を任意指定できるようにします。これにより、各機器の発熱を機器自身に持たせ、
  かつ光学ベンチ／光学パネルを設定温度で一定に保ち、ミラー・干渉計の熱ドリフトを最小化できます。

  ## ベースブランチ（スタックPR）
  本PRは **`feat/arbitrary-internal-panels`（内部パネル機能）にスタック**しています。
  そちらのPRがマージされた後にレビュー/マージしてください（diff はヒータ関連の2コミットのみ）。

  - `a25134f` feat: per-component internal heat & thermostatic heater
  - `0fc44b0` feat: thermostatic heater for internal panels

  ## 変更内容

  ### コンポーネント（`component_properties.yaml`）
  ```yaml
  component_properties:
    OBC:
      name: "On-Board Computer"
      mass: 1.5
      specific_heat: 800.0
      internal_heat: 5.0          # 任意: 定常発熱 [W]
      mounting:
        panel: "MX"
        thermal_conductance: 5.0
```
## 内部パネル（internal_panels.yaml）
```yaml
  internal_panels:
    OPTICS:
      name: "Optics Panel (SiC)"
      material: "SiC"
      area: 0.16
      thickness: 9.0
      internal_heat: 2.0
      heater:                     # 任意: サーモスタット式ヒータ
        setpoint_K: 283.15        # 設定温度 [K]（未満なら power_W を投入）
        power_W: 80.0             # 最大投入電力 [W]
      conductances:
        PZ: 1.6
        MZ: 1.6
```
  熱収支に
  Q = 伝導 + internal_heat + heater_heat(自温度)
  を加える形で、コンポーネント・内部パネルとも同一ロジックで処理します。

## 変更ファイル

  - utils/dataclasses.py: ComponentProperties と InternalPanel にinternal_heat / heater_setpoint_K / heater_power_W と heater_heat() を追加
  - utils/config_loader.py: internal_heat と heater:{setpoint_K, power_W} の読み込み（load_component_properties / load_internal_panels）
  - utils/thermal_utils.py: コンポーネント／内部パネルの熱収支に発熱＋ヒータ熱を加算

## 後方互換性

  internal_heat / heater を未指定なら発熱0・ヒータ無効で、挙動は従来と完全一致します。既存の回帰テスト（既定設定での温度履歴比較）は PASS。

##  動作確認

  - 回帰テスト 2件 PASS
  - 光学パネル(SiC)に 10℃ 設定のヒータを付与 → 十分な電力で 平均 10.3℃・リップル ~1.5℃ に保持
  （ON/OFFサーモスタットの上限が設定温度で頭打ちになることを確認）

## 制限事項

  - ヒータは ON/OFF（バンバン）制御で PID 等の連続制御ではない
  - 制御周期は解析の time_step に一致
  - ヒータ投入電力の電力収支上限チェック・時系列出力は未対応
  - 強く構体結合した内部パネルを温調するには相応のヒータ電力が必要（結合 vs 電力のトレードオフ）
  
  ## テスト
  
<img width="1000" height="600" alt="temperature_components" src="https://github.com/user-attachments/assets/4385bc89-079c-4a97-9de9-3393df9d372b" />
